### PR TITLE
Frank/rust refactor 003 add 015

### DIFF
--- a/src/003/003.rs
+++ b/src/003/003.rs
@@ -32,8 +32,11 @@ fn get_prime_factors(n: i64) -> Vec<i64> {
         .collect::<Vec<i64>>()
 }
 
+fn solve() -> i64 {
+    get_prime_factors(600851475143).into_iter().max().unwrap()
+}
+
 fn main() {
-    if let Some(maximum_value) = get_prime_factors(600851475143).iter().max() {
-        println!("{}", maximum_value);
-    }
+    let result = solve();
+    println!("{}", result);
 }

--- a/src/015/015.rs
+++ b/src/015/015.rs
@@ -1,0 +1,12 @@
+fn combination(n: u64, k: u64) -> u64 {
+    (0..k).fold(1, |acc, i| acc * (n - i) / (i + 1))
+}
+
+fn solve() -> u64 {
+    combination(40, 20)
+}
+
+fn main() {
+    let result = solve();
+    println!("{}", result);
+}


### PR DESCRIPTION
**Description**

Uses 

```rust
get_prime_factors(600851475143).into_iter().max().unwrap()
```

Instead of 

```rust
if let Some(maximum_value) = get_prime_factors(600851475143).iter().max() { ... }
```

And adds `015.rs`.