### PR TITLE
Rust 036

### DIFF
--- a/src/036/README.md
+++ b/src/036/README.md
@@ -1,5 +1,5 @@
 https://projecteuler.net/problem=036
 
-The decimal number, 585 = 10010010012 (binary), is palindromic in both bases.
+The decimal number, 585 = 1001001001<sub>2</sub> (binary), is palindromic in both bases.
 Find the sum of all numbers, less than one million, which are palindromic in base 10 and base 2.
 (Please note that the palindromic number, in either base, may not include leading zeros.)

--- a/src/036/README.md
+++ b/src/036/README.md
@@ -1,0 +1,5 @@
+https://projecteuler.net/problem=036
+
+The decimal number, 585 = 10010010012 (binary), is palindromic in both bases.
+Find the sum of all numbers, less than one million, which are palindromic in base 10 and base 2.
+(Please note that the palindromic number, in either base, may not include leading zeros.)

--- a/src/036/p036.rs
+++ b/src/036/p036.rs
@@ -1,0 +1,30 @@
+fn is_palindrome(n: i32) -> bool {
+    let reversed: String = n.to_string().chars().rev().collect();
+    reversed == n.to_string()
+}
+
+fn is_binary_palindrome(n: i32) -> bool {
+    let binary = format!("{:b}", n);
+    let reversed: String = format!("{:b}", n).chars().rev().collect();
+    reversed == binary
+}
+
+fn double_base_palindrome(n: i32) -> bool {
+    is_palindrome(n) && is_binary_palindrome(n)
+}
+
+fn sum_of_double_palindrome_numbers_below(limit: i32) -> i32 {
+    (0..limit)
+        .into_iter()
+        .filter(|&x| double_base_palindrome(x))
+        .sum()
+}
+
+fn solve() -> i32 {
+    sum_of_double_palindrome_numbers_below(1000000)
+}
+
+fn main() {
+    let result = solve();
+    println!("{}", result);
+}


### PR DESCRIPTION
### How the solution works

Simple iteration filtering double base palindromes.

```rust
(0..limit)
        .into_iter()
        .filter(|&x| double_base_palindrome(x))
        .sum()
```

### Performance

[Rust](https://tio.run/##jVLLTsMwELznK5YeIluCqMAtqPARfIBlNw5Y8qOynVLU5tvDxkloFBTRvazWO94Z79g3IXZdbUEFduBa2co7I4ktQT0/UXh4BeGchnMGGFpG8PIofZBVCe/RK/sBO7BFdCykitBi/8l9wIzAvnJay30k9CVNmG7DbnEta7NsUCGU5f77NjEDFiXUzhse78jmXIp2cw925FtR/Bd@u@yBc9RbuUZoyQQP8n/FixVTyPOVB0/rCI1hrmYjyxXBbGMEKmJCavdFtDIqXikxj4xkWxSpSVPZR6Esrl1F6cnssFa6P7nkp8vam050hkdhv54Fp4@SLJhvVP64TTGNMlxZnDT/baHRER0bSQY7Dmhj1Db599b7N8Cw22Zd9wM)

```
Real time: 3.988 s
User time: 3.564 s
Sys. time: 0.125 s
CPU share: 92.53 %
```