### PR TITLE
Clojure 002

### DIFF
--- a/src/002/p002.cljc
+++ b/src/002/p002.cljc
@@ -1,0 +1,38 @@
+; works in both clojure and clojurescript! 
+
+(defn fib-iterator 
+  "Function that given a vector of 2 numbers, returns the next 'fibonacci' step: [0 1] => [1 1], [1 1] => [1 2]."
+  [[fj fk]] [fk (+ fj fk)])
+
+(def fib-lazy
+  "Lazy windowed fibonacci sequence."
+  (iterate ; seq[i+1] = f(seq[i]), since seq is lazy, we can have infinite terms!
+    fib-iterator ; our updating/step function f
+    [1 1])) ; initial input, seq[0]
+
+(def treat-fib
+  "Treatment to get the actual sequence we need, composing a filter and getting only the second term"
+  (comp ; composition of transducers (think fancy combination of higher-order and simpler functions)
+    (map second) ; gets the second term of the sequence, the actual fibonacci term
+    (filter even?))) ; now we only have even terms
+
+(defn limited-sum
+  "Returns a simple sum that 'breaks'/stops our procedure when one input reaches limit L"
+  [L] ; our upper limit 
+  (fn ; lambda
+    ([total] total) ; arity 1: identity, simply returns total
+    ([acc n] ; arity 2, for each step
+      (if (< n L) ; if n < L
+              (+ acc n) ; sums up accumulator and new step and returns
+              (reduced acc))))) ; else returns accumulator
+
+(defn result
+  "Function for transduction (think generalized map-reduce)"
+  [fib]
+  (transduce ; this guy is the golden gem
+    treat-fib ; our treatment of the input (map+filter)
+    (limited-sum (* 4 1e6)) ; accumulator/reducing function, just our limited sum
+    0 ; initial value, the identity of our operation +
+    fib)) ; the input
+
+(println (result fib-lazy))

--- a/src/002/p002.cljc
+++ b/src/002/p002.cljc
@@ -1,43 +1,11 @@
-; works in both clojure and clojurescript!
-; you can run it with either lumo ($ lumo p002.cljc) (much faster startup due to node)
-; or via boot ($ boot -f p002.cljc) (slow startup, but faster if you run it from repl)
-; to run from lein you may need to rename it to p002.clj
+; works in both clojure and clojurescript
 
-(defn fib-iterator 
-  "Function that given a vector of 2 numbers, returns the next 'fibonacci' step: [0 1] => [1 1], [1 1] => [1 2]."
-  [[fj fk]] [fk (+ fj fk)])
-
-(def fib-lazy
-  "Lazy windowed fibonacci sequence."
-  (iterate ; seq[i+1] = f(seq[i]), since seq is lazy, we can have infinite terms!
-    fib-iterator ; our updating/step function f
-    [1 1])) ; initial input, seq[0]
-
-(def treat-fib
-  "Treatment to get the actual sequence we need, composing a filter and getting only the second term"
-  (comp ; composition of transducers (think fancy combination of higher-order and simpler functions)
-    (map second) ; gets the second term of the sequence, the actual fibonacci term
-    (filter even?))) ; now we only have even terms
-
-(defn limited-sum
-  "Returns a simple sum that 'breaks'/stops our procedure when one input reaches limit L"
-  [L] ; our upper limit 
-  (fn ; lambda
-    ([total] total) ; arity 1: identity, simply returns total
-    ([acc n] ; arity 2, for each step
-      (if (< n L) ; if n < L
-              (+ acc n) ; sums up accumulator and new step and returns
-              (reduced acc))))) ; else returns accumulator
-
-(defn result
-  "Function for transduction (think generalized map-reduce)"
-  [fib]
-  (transduce ; this guy is the golden gem
-    treat-fib ; our treatment of the input (map+filter)
-    (limited-sum (* 4 1e6)) ; accumulator/reducing function, just our limited sum
-    0 ; initial value, the identity of our operation +
-    fib)) ; the input
-
-(defn solve [] (result fib-lazy))
+(defn solve [] 
+  (let [fib-iterator (fn [[fj fk]] [fk (+ fj fk)])
+        fib-lazy (iterate fib-iterator [1 1])
+        treat-fib (comp (map second) (filter even?))
+        limited-sum (fn ([total] total)
+                        ([acc n] (if (< n (* 4 1e6)) (+ acc n) (reduced acc))))]
+    (transduce treat-fib limited-sum 0 fib-lazy)))
 
 (prn (solve))

--- a/src/002/p002.cljc
+++ b/src/002/p002.cljc
@@ -1,4 +1,7 @@
-; works in both clojure and clojurescript! 
+; works in both clojure and clojurescript!
+; you can run it with either lumo ($ lumo p002.cljc) (much faster startup due to node)
+; or via boot ($ boot -f p002.cljc) (slow startup, but faster if you run it from repl)
+; to run from lein you may need to rename it to p002.clj
 
 (defn fib-iterator 
   "Function that given a vector of 2 numbers, returns the next 'fibonacci' step: [0 1] => [1 1], [1 1] => [1 2]."
@@ -35,4 +38,6 @@
     0 ; initial value, the identity of our operation +
     fib)) ; the input
 
-(println (result fib-lazy))
+(defn solve [] (result fib-lazy))
+
+(prn (solve))


### PR DESCRIPTION
### How the solution works

Instead of using a function to recursively retrieve the elements in the sequence, we could use a "seed" and use a update/step function (f: s[j] => s[j+1]) to get a lazy (infinite!) sequence.

Then we use transduction-style iteration to treat and filter our sequence, and at the same time accumulating it (no intermediary mapped or filtered sequences!). Note that since our initial sequence is lazy, we only compute them at the time we filter and sum them, so we actually go over it only once!

### Performance

[Try it online](https://tio.run/##XVBNa8QgEL3vr3jHsSXQQOmp0B8iHqyOkF0TgzEL7Z/PjgYW27mMw/uYN7qYrnvm4yDPYcGW4p2hDS4AKHKBDtP3MBXOtqQMEo7W4YpwM0awG@gVbVRGVc1ZVRPt7w/oVDL@uOgRY08vmW0ZhAJyaV5Bs12xsUuLV7JyiiIE33n5Up0qTrM4@mHb55aLdEnFRoPWOuL/Im2dw2IkXQB9QqQveMfIH0rVexoqr8x@d@zrrKTM6Ugl22WrSJe7z/L2PF/VuBdas2xoPyv@x/EA)
```
Real time: 2.733 s
User time: 4.955 s
Sys. time: 0.156 s
CPU share: 187.00 %
Exit code: 0
```