### PR TITLE
Crystal 048

### DIFF
--- a/src/048/README.md
+++ b/src/048/README.md
@@ -1,0 +1,4 @@
+https://projecteuler.net/problem=048
+
+The series, 1^1 + 2^2 + 3^3 + ... + 10^10 = 10405071317.
+Find the last ten digits of the series, 1^1 + 2^2 + 3^3 + ... + 1000^1000.

--- a/src/048/p048.cr
+++ b/src/048/p048.cr
@@ -1,0 +1,21 @@
+require "big"
+
+struct BigInt
+  def self_power
+    self ** self
+  end
+end
+
+def sum_self_powers(limit)
+  (1..limit).map(&.to_big_i.self_power).sum
+end
+
+def solve
+  # Big number as str
+  str = sum_self_powers(1000).to_s
+  size = str.size
+  # Last ten digits of str
+  str[size - 10..size]
+end
+
+puts solve


### PR DESCRIPTION
- [✅] I checked [CONTRIBUTING.md](https://github.com/FrankKair/polyglot-euler/blob/master/CONTRIBUTING.md) for my programming language of choice.

### How the solution works

Maps the self powers (x^x), sums it and then transforms to string to get the last digits.
This is memory inefficient because we have to allocate a string.
At first a tried to do the following:

```crystal
mod = 10 ** 10
self_powers(1000) % mod
```

But for some reason I got the wrong result.
Maybe something to do with big int arithmetics?

### Performance

[Crystal](https://tio.run/##VYxBDoIwEEX3PcWEFSVxUg7gSYwhKINp0gJ2iqLi2WtbiYmbyZ/3f97ZPdi3JgRH11k7guKkL4UQHfXAZPpmGu/kuDTaai8FQFmjH5s4ajRipr9fom0neMG6rLBAVcXzRp6toKHbjKO5UZQMsP@z10opmTwcS9ZPiv2AKaTxIZMd1AozO36F0@x5M4bwAQ).

```
Real time: 1.748 s
User time: 1.969 s
Sys. time: 0.306 s
CPU share: 130.13 %
```