### PR TITLE
Clojure 009

### DIFF
--- a/src/009/p009.clj
+++ b/src/009/p009.clj
@@ -1,11 +1,11 @@
-; works in both clojure and clojurescript
+(defn square [x] (Math/pow x 2))
+
+(defn sqrt [x] (Math/sqrt x))
+
+(defn sum-1000? [x] (== 1000 (reduce + 0 x)))
 
 (defn solve []
-  (let [square #(* % %)
-        sqrt #(Math/sqrt %)
-        sum-1000? #(== 1000 (apply + %))
-        candidates (for [b (range 700 5 -1)
-                         a (range 4 b)]
+  (let [candidates (for [b (range 700 5 -1), a (range 4 b)]
                         [a b (sqrt (+ (square a) (square b)))])]
         (transduce (comp (filter sum-1000?)
                          cat

--- a/src/009/p009.cljc
+++ b/src/009/p009.cljc
@@ -1,0 +1,16 @@
+; works in both clojure and clojurescript
+
+(defn solve []
+  (let [square #(* % %)
+        sqrt #(Math/sqrt %)
+        sum-1000? #(== 1000 (apply + %))
+        candidates (for [b (range 700 5 -1)
+                         a (range 4 b)]
+                        [a b (sqrt (+ (square a) (square b)))])]
+        (transduce (comp (filter sum-1000?)
+                         cat
+                         (map int))
+                   * 1
+                   candidates)))
+
+(prn (solve))


### PR DESCRIPTION
Hello! Thank you for your contribution to `polyglot-euler`.
- [✅] I checked [CONTRIBUTING.md](https://github.com/FrankKair/polyglot-euler/blob/master/CONTRIBUTING.md) for my programming language of choice.

### How the solution works

Clojure doesn't have its own numeric tower, so we have to define `square` and `sqrt` (the later returns a float)

`sum-1000?` is a predicate that checks if a group of 3 numbers sums 1000 (using `==` instead of `=` ignores "type"; `(= 1 1.0)` is `false`, but `(== 1 1.0)` is `true`)

`candidates` is a lazy sequence of 3-vectors of numbers, built from ranges.
5 < b <= 700 ; heuristics alert: 700 is a reasonable number to start our search, and we know b can't be smaller than say, 5. in the code its reverses so we start looking from 700.
4 <= a < b ;
and c is defined as √(a^2 + b^2)

then we keep only the vectors that pass our `sum-1000?` test, turn them to ints (to keep sure we don't print anything in "scientific notation" and get their product.

### Performance

[Try it online!](https://tio.run/##fZFBasMwEEX3PsWHEhglhNrQ0lXICXIC48VYVloXWVYkOdDTO2OH1IEmndVn5unzZ6Rt/z0EM47UmKND7O3ZoKwygKxJKONp4GDwQmussFLSv1Y8hSTdA6ev11nfz4ZuW@R5vhdgt8MkQey9/cFGuAXU7Jq24WQi6NgHlDUosPs0@JAn79gWC/un@Ma@oVbVU65kiOsckTaTmPdh9StrpVR1Z0BJbGMzaAPSfeclWmuTCcta/4TSnJ4PqWOP1iX10GCNInvoeLuR5Mwy8sFJ9OmblBrHCw "Clojure – Try It Online")

```
Real time: 3.021 s
User time: 5.468 s
Sys. time: 0.206 s
CPU share: 187.78 %
```
