### PR TITLE
Clojure 007

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,22 @@ const result = solve()
 console.log(result)
 ```
 
+### Julia
+
+```julia
+function func(x)
+    # Body
+end
+
+function solve()
+    # Body
+end
+
+result = solve()
+
+println(result)
+```
+
 ### Lua
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Haskell
 - Java
 - JavaScript
+- Julia
 - Lua
 - Python
 - Perl

--- a/src/001/p001.jl
+++ b/src/001/p001.jl
@@ -1,0 +1,11 @@
+function isdivisible(n)
+   (0 == (n % 3)) || (0 == (n % 5))
+end
+
+function solve()
+   sum(filter(isdivisible, 1:999))
+end
+
+result = solve()
+
+println(result)

--- a/src/007/p007.cljc
+++ b/src/007/p007.cljc
@@ -1,0 +1,17 @@
+; works in both clojure and clojurescript
+
+(defn next-primes [[primes new]] 
+  (let [new* (inc (inc new))] 
+      (if (some #(= 0 (rem new %)) primes)
+          [primes new*]
+          [(conj primes new) new*])))
+
+(defn solve []
+  (let [primes (->> [[2] 3]
+                    (iterate next-primes)
+                    (map first)
+                    dedupe
+                    (map peek))]
+        (first (drop 10000 primes))))
+
+(prn (solve))


### PR DESCRIPTION
Hello! Thank you for your contribution to `polyglot-euler`.
- [✅] I checked [CONTRIBUTING.md](https://github.com/FrankKair/polyglot-euler/blob/master/CONTRIBUTING.md) for my programming language of choice.

### How the solution works

`next-primes` is a function that takes a vector of 2 components: [`primes`, `new`] and returns [`primes*`, `new`]
`primes` is a vector of numbers assumed to be primes
`new` is a prime candidate, assumed to be odd
`primes*` is `primes`, but with `new` appended if it is not divisible by any number in `primes`
`new*` is `new`+2 (again odd)

we build a lazy sequence of successive iterations of `next-primes` upon [[2], 3], get only the `primes` vector, remove duplicates (for when `new` is not prime, then `primes` repeats itself), and get the last prime in `primes`.
from that sequence, we drop 10000 elements and get the 10001st

### Performance

[Try it online!](https://tio.run/##dVDLDoIwELzzFZMYk10TEh9n@RHSg4ElqULblKL@PRaLygHn0HQ7s9udqVp7HbyMI9XSGBh5htx53UmPspwvRh5KIQOolYAyljuQNlU6Ysn8pieQbkC97QQbOmMP8tJNEmyZkebxLJ2w@GKnlu9UWXPFj@UkYeYsS6v2tr0LSvXdaxZTXhRx96PCaTnxB9JB/CXI0iyvK7uLQ6N9H9b5WurByf9WJ3KL2XwF9J4Fqr11OOwjPpEkX86bKbzoi3kcXw "Clojure – Try It Online")

```
Real time: 5.432 s
User time: 8.068 s
Sys. time: 0.329 s
CPU share: 154.58 %
```
