### PR TITLE
Clojure 007

### DIFF
--- a/src/007/p007.cljc
+++ b/src/007/p007.cljc
@@ -1,0 +1,17 @@
+; works in both clojure and clojurescript
+
+(defn next-primes [[primes new]] 
+  (let [new* (inc (inc new))] 
+      (if (some #(= 0 (rem new %)) primes)
+          [primes new*]
+          [(conj primes new) new*])))
+
+(defn solve []
+  (let [primes (->> [[2] 3]
+                    (iterate next-primes)
+                    (map first)
+                    dedupe
+                    (map peek))]
+        (first (drop 10000 primes))))
+
+(prn (solve))


### PR DESCRIPTION
Hello! Thank you for your contribution to `polyglot-euler`.
- [✅] I checked [CONTRIBUTING.md](https://github.com/FrankKair/polyglot-euler/blob/master/CONTRIBUTING.md) for my programming language of choice.

### How the solution works

- `next-primes` is a function that takes a vector of 2 components: `[primes, new]` and returns `[primes*, new]`
- `primes` is a vector of numbers assumed to be primes
- `new` is a prime candidate, assumed to be odd
- `primes*` is `primes`, but with `new` appended if it is not divisible by any number in `primes`
- `new*` is `new`+2 (again odd)

We build a lazy sequence of successive iterations of `next-primes` upon` [[2], 3]`, then get only the `primes` vector, remove duplicates (for when `new` is not prime, then `primes` repeats itself), and get the last prime in `primes`.
From that sequence, we drop 10000 elements and get the 10001st

### Performance

[Try it online!](https://tio.run/##dVBBbsIwELznFSNVSLtISLQ9VuUjkQ@ps1ENiW3ZBvr74OAEcqBzsHY94/HO6t4dz0HG8QtXF04RxuLHpV/oQqCx7VJHHYxPVUWtdBZW/tLOBzNIRF3PhZWrUqgA6iWhzu0WZKwuR26Z7/QEMh0oukHwRt/Yg4IMkwQbZhQ/nqUTVl9s1fqetLNHPFkuEmZeRo2uvwhq9ZhrFtPucMizfyh8rh2fIJMkNEnWYfm1cmg8OhNies230p69/P/Ui5zybh4CunuB2uA83vcZy0pKLh/stLyci3kcbw "Clojure – Try It Online")

```
Real time: 5.328 s
User time: 7.858 s
Sys. time: 0.200 s
CPU share: 151.23 %
```
