### PR TITLE
CircleCI integration + Linguist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ aliases:
     run:
       name: Install github-linguist
       command: |
+        sudo apt-get install cmake
         gem install github-linguist
   - &run-linguist
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ defaults: &defaults
     - image: circleci/ruby
 
 jobs:
-  default:
+  build:
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+aliases:
+  - &install-linguist
+    run:
+      name: Install github-linguist
+      command: |
+        gem install github-linguist
+  - &run-linguist
+    run:
+      name: Run github-linguist on repository
+      command: |
+        github-linguist
+
+defaults: &defaults
+  docker:
+    - image: circleci/ruby
+
+version: 2
+jobs:
+  default:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install-linguist
+      - <<: *run-linguist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ aliases:
     run:
       name: Run github-linguist on repository
       command: |
-        github-linguist
+        linguist
 
 defaults: &defaults
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2
+
 aliases:
   - &install-linguist
     run:
@@ -14,7 +16,6 @@ defaults: &defaults
   docker:
     - image: circleci/ruby
 
-version: 2
 jobs:
   default:
     <<: *defaults


### PR DESCRIPTION
Hello guys! 😄 

Following our discussion on #39, I set up a simple `config.yml` configuration file for [CircleCI](https://circleci.com/).

Right now it only runs [linguist](/github/linguist/) on the repository's base directory and displays the results on CircleCI's dashboard, as seen below.

![CircleCI + github/linguist](https://i.imgur.com/r99lCIQ.png)

It can be improved further if the results are submitted somewhere, maybe on the project's [README](../blob/master/README.md).

