### PR TITLE
Fixing github-linguist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ aliases:
   - &run-linguist
     run:
       name: Run github-linguist on repository
-      command: linguist
+      command: github-linguist
   - &generate-html-chart
     run:
       name: Run script that generates html chart file
-      command: ./chart.sh
+      command: ./scripts/chart.sh
   - &move-chart-file
     run:
       name: Moving generated chart file to artifacts directory

--- a/scripts/chart.sh
+++ b/scripts/chart.sh
@@ -28,7 +28,7 @@ cat > $FILENAME << EOF
         data.addRows([
 EOF
 
-linguist | while read percentage language
+github-linguist | while read percentage language
     do echo "          ['$language', ${percentage%?}]," >> $FILENAME
 done
 


### PR DESCRIPTION
- [github-linguist version 7.0.0](https://github.com/github/linguist/releases/tag/v7.0.0) has renamed the `linguist` command to `github-linguist`.
- Also moving file `chart.sh` to the scripts/ folder.