### PR TITLE
Using github's colors on chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,20 @@
 version: 2
 
 aliases:
-  - &install-cmake
-    run:
-      name: Install CMake
-      command: sudo apt-get install cmake
   - &install-linguist
     run:
       name: Install github-linguist
-      command: gem install github-linguist
+      command: |
+        sudo apt-get install cmake
+        gem install github-linguist:7.0.0
   - &run-linguist
     run:
       name: Run github-linguist on repository
       command: github-linguist
   - &generate-html-chart
     run:
-      name: Run script that generates html chart file
-      command: ./scripts/chart.sh
-  - &move-chart-file
-    run:
-      name: Moving generated chart file to artifacts directory
-      command: mv chart.html /tmp/
+      name: Generate language chart html file
+      command: ./scripts/chart.sh > /tmp/chart.html
   - &store-artifact
     store_artifacts:
       path: /tmp/chart.html
@@ -34,9 +28,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - <<: *install-cmake
       - <<: *install-linguist
       - <<: *run-linguist
       - <<: *generate-html-chart
-      - <<: *move-chart-file
       - <<: *store-artifact

--- a/scripts/chart.sh
+++ b/scripts/chart.sh
@@ -1,9 +1,100 @@
 #! /bin/bash
 set -e
 
-FILENAME=chart.html
+random_color () {
+  openssl rand -hex 3
+}
 
-cat > $FILENAME << EOF
+get_language_color () {
+    case $1 in
+    C)
+      echo 555555
+      ;;
+    C++)
+      echo f34b7d
+      ;;
+    Clojure)
+      echo d95959
+      ;;
+    Crystal)
+      echo 776791
+      ;;
+    D)
+      echo ba595e
+      ;;
+    Elixir)
+      echo 6b4b7a
+      ;;
+    Erlang)
+      echo b83998
+      ;;
+    Futhark)
+      echo ffffff
+      ;;
+    Go)
+      echo 375eab
+      ;;
+    Groovy)
+      echo e69f56
+      ;;
+    Haskell)
+      echo 5e5086
+      ;;
+    Java)
+      echo b07219
+      ;;
+    JavaScript)
+      echo f1e05a
+      ;;
+    Julia)
+      echo a270ba
+      ;;
+    Lua)
+      echo 000080
+      ;;
+    OCaml)
+      echo 3be133
+      ;;
+    Perl)
+      echo 0298c3
+      ;;
+    Python)
+      echo 3572A5
+      ;;
+    Red)
+      echo f50000
+      ;;
+    Ruby)
+      echo 701516
+      ;;
+    Rust)
+      echo dea584
+      ;;
+    Scala)
+      echo c22d40
+      ;;
+    Scheme)
+      echo 1e4aec
+      ;;
+    Shell)
+      echo 89e051
+      ;;
+    Swift)
+      echo ffac45
+      ;;
+    TypeScript)
+      echo 2b7489
+      ;;
+    *)
+      random_color
+      ;;
+    esac
+}
+
+tmpfile=$(mktemp /tmp/linguist.XXXXXX)
+github-linguist > $tmpfile
+
+cat << EOF
 <html>
   <head>
     <!--Load the AJAX API-->
@@ -28,17 +119,30 @@ cat > $FILENAME << EOF
         data.addRows([
 EOF
 
-github-linguist | while read percentage language
-    do echo "          ['$language', ${percentage%?}]," >> $FILENAME
+cat $tmpfile | while read percentage language
+    do echo "          ['$language', ${percentage%?}],"
 done
 
-cat >> $FILENAME << EOF
+cat << EOF
         ]);
 
         // Set chart options
-        var options = {'title':'Languages',
-                       'width':800,
-                       'height':600};
+        var options = {'title': 'Polyglot Euler Languages',
+                       'width': 800,
+                       'height': 600,
+                       // is3D: true,
+                       'colors': [
+EOF
+
+cat $tmpfile | while read percentage language
+    do echo "                         '#`get_language_color $language`',"
+done
+
+cat << EOF
+                       ],
+                       'tooltip': {'text': 'percentage'},
+                       'pieSliceText': 'none',
+                       };
 
         // Instantiate and draw our chart, passing in some options.
         var chart = new google.visualization.PieChart(document.getElementById('chart_div'));
@@ -53,3 +157,5 @@ cat >> $FILENAME << EOF
   </body>
 </html>
 EOF
+
+rm $tmpfile


### PR DESCRIPTION
Color list is a big switch case on the script.
I've mapped our most used languages, any missing one will get a random color.
Also freezing `github-linguist` version in order to avoid breaking again.

Chart now looks like this:
![Language Pie Chart](https://i.imgur.com/fooHH2E.png)

If desired, also there's a 3D version:
![3D Language Pie Chart](https://i.imgur.com/qyY18kr.png)
